### PR TITLE
Fix occasional frame skipping after calling `pause`

### DIFF
--- a/src/library/player.js
+++ b/src/library/player.js
@@ -114,7 +114,7 @@ export default class extends EventEmitter {
                 do {
                     this.renderNextFrame();
                     nextRenderTime += this.currentFrame.delay / this.playbackRate;
-                } while (!this._ended && now > nextRenderTime);
+                } while (!this._ended && !this._paused && now > nextRenderTime);
             }
             requestAnimationFrame(tick);
         };


### PR DESCRIPTION
## issue

After calling `player.pause` still resulted in multiple calls to renderNextFrame, causing frame skipping.