### PR TITLE
fix: prevent animation speed-up on multiple play() calls

### DIFF
--- a/docs/index.js
+++ b/docs/index.js
@@ -641,7 +641,7 @@
 	        _this._ended = false;
 	        _this._paused = true;
 	        _this._numPlays = 0;
-
+	        _this._rafId = null;
 	        _this._apng = apng;
 	        _this.context = context;
 	        _this.stop();
@@ -712,6 +712,10 @@
 	        value: function play() {
 	            var _this2 = this;
 
+	            if (this._rafId) {
+                cancelAnimationFrame(this._rafId);
+	            }
+
 	            this.emit('play');
 
 	            if (this._ended) {
@@ -734,14 +738,18 @@
 	                        nextRenderTime += _this2.currentFrame.delay / _this2.playbackRate;
 	                    } while (!_this2._ended && !_this2._paused && now > nextRenderTime);
 	                }
-	                requestAnimationFrame(tick);
+	                _this2._rafId = requestAnimationFrame(tick);
 	            };
-	            requestAnimationFrame(tick);
+	            _this2._rafId = requestAnimationFrame(tick);
 	        }
 	    }, {
 	        key: 'pause',
 	        value: function pause() {
 	            if (!this._paused) {
+	                if (this._rafId) {
+                    cancelAnimationFrame(this._rafId);
+                    this._rafId = null;
+	                }
 	                this.emit('pause');
 	                this._paused = true;
 	            }
@@ -749,6 +757,10 @@
 	    }, {
 	        key: 'stop',
 	        value: function stop() {
+	            if (this._rafId) {
+                cancelAnimationFrame(this._rafId);
+                this._rafId = null;
+	            }
 	            this.emit('stop');
 	            this._numPlays = 0;
 	            this._ended = false;


### PR DESCRIPTION


### Problem Background
When using apng-js, multiple play triggers cause abnormal acceleration in animation playback speed. This issue stems from defects in the original apng-js library's handling of animation loops.

### Root Cause
1. The original apng-js library fails to properly manage the lifecycle of `requestAnimationFrame`
2. Each `play()` method call creates a new animation loop without cleaning up the previous ones
3. Multiple animation loops running in parallel result in cumulative rendering frequencies, causing abnormal acceleration in playback speed

### Key Modifications
1. Add `_rafId` property to track `requestAnimationFrame` ID:
```javascript
_rafId = null;  // Add _rafId to track requestAnimationFrame
```

2. Clean up old animation loops in the `play()` method:
```javascript
if (this._rafId) {
    cancelAnimationFrame(this._rafId);
}
```

3. Store `requestAnimationFrame` ID in the animation loop:
```javascript
_this2._rafId = requestAnimationFrame(tick);
```

4. Add animation loop cleanup in `pause()` and `stop()` methods:
```javascript
if (this._rafId) {
    cancelAnimationFrame(this._rafId);
    this._rafId = null;
}
```

### Solution Results
1. Ensures only one animation loop runs at a time
2. Prevents speed abnormalities caused by multiple overlapping animation loops
3. Maintains stable animation playback speed as expected
4. Improves component performance and reliability

This fix not only resolves the specific speed abnormality issue but also enhances the APNG player implementation, making it more robust and reliable. 